### PR TITLE
Change BaseRow var to open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v0.0.4](https://github.com/LabLamb/PNPForm/tree/v0.0.4) (2020-03-21)
+
+[Full Changelog](https://github.com/LabLamb/PNPForm/compare/v0.0.3...v0.0.4)
+
+**Implemented enhancements:**
+
+- Update baserow [\#17](https://github.com/LabLamb/PNPForm/pull/17) ([LabLamb](https://github.com/LabLamb))
+
+**Merged pull requests:**
+
+- Update v0.0.3 CHANGLOG [\#15](https://github.com/LabLamb/PNPForm/pull/15) ([LabLamb](https://github.com/LabLamb))
+
 ## [v0.0.3](https://github.com/LabLamb/PNPForm/tree/v0.0.3) (2020-03-21)
 
 [Full Changelog](https://github.com/LabLamb/PNPForm/compare/v0.0.2...v0.0.3)

--- a/PNPForm.podspec
+++ b/PNPForm.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "PNPForm"
-  spec.version      = "0.0.4"
+  spec.version      = "0.0.5"
   spec.summary      = "A swift library that provides a form view without have to conform any ViewController."
   spec.homepage     = "https://github.com/LabLamb/PNPForm"
   spec.screenshots  = "https://github.com/LabLamb/PNPForm/blob/develop/.github/images/example.gif"

--- a/PNPForm/Form/Row/BaseRow.swift
+++ b/PNPForm/Form/Row/BaseRow.swift
@@ -11,7 +11,7 @@ open class BaseRow: UIView {
     let valueView: UIView
     let valueContainer: UIView
     
-    public var label: Any {
+    open var label: Any {
         get {
             return ""
         }
@@ -19,7 +19,7 @@ open class BaseRow: UIView {
         set {}
     }
     
-    public var value: String? {
+    open var value: String? {
         get {
             return nil
         }


### PR DESCRIPTION
# PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


# What is the current behavior?
Podspec is v0.0.4
BaseRow value and label is public
# What is the new behavior?
Podspec is v0.0.5
BaseRow value and label is open
# Does this PR introduce a breaking change?

- [ ] Yes
- [X] No